### PR TITLE
Fix resolving of native dependencies for ARM64 MacOS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://www.hdfgroup.org/</PackageProjectUrl>
     <Product>HDF.PInvoke</Product>
     <RepositoryUrl>https://github.com/HDFGroup/HDF.PInvoke.1.10</RepositoryUrl>
-    <Version>1.10.612</Version>
+    <Version>1.10.613</Version>
     <Prerelease></Prerelease>
 
     <!-- Derived properties -->


### PR DESCRIPTION
Running the x64 MacOS version on an Apple Silicon machine does not find the native .dylib files using vmmap. Combined the dependencies resolution from before 1.10.611 with the latest version since they are not mutually exclusive.